### PR TITLE
Add GitHub to social links

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -29,6 +29,11 @@ DEFAULT_PAGINATION = 10
 DISPLAY_CATEGORIES_ON_MENU = False
 DISPLAY_PAGES_ON_MENU = False
 
+# Social
+SOCIAL = (
+    ('github', 'https://github.com/jelmer/xandikos'),
+)
+
 MENUITEMS = (
     ('News', '/news.html'),
     ('Clients', '/clients.html'),


### PR DESCRIPTION
I think this will add a link in the footer under "Social", but I haven't actually run the code to check, I'm just going from the docs on the theme here:

https://github.com/petrnohejl/MinimalXY/tree/92422641a2bd6b6f4d1f48be4f7dad92b44071ae

I accidentally submitted this to my own fork a couple of days ago. 🙈 